### PR TITLE
[Bug Fix] Fixed player being kicked when towing vehicle. Small optimi…

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -30,13 +30,12 @@ local function getVehicleInDirection(coordFrom, coordTo)
 end
 
 local function isTowVehicle(vehicle)
-    local retval = false
     for k in pairs(Config.Vehicles) do
-        if GetEntityModel(vehicle) == GetHashKey(k) then
-            retval = true
+        if GetEntityModel(vehicle) == joaat(k) then
+            return true
         end
     end
-    return retval
+    return false
 end
 
 -- Old Menu Code (being removed)
@@ -291,8 +290,8 @@ RegisterNetEvent('qb-tow:client:TowVehicle', function()
             local coordB = GetOffsetFromEntityInWorldCoords(playerped, 0.0, 5.0, 0.0)
             local targetVehicle = getVehicleInDirection(coordA, coordB)
 
-            if NpcOn and CurrentLocation ~= nil then
-                if GetEntityModel(targetVehicle) ~= GetHashKey(CurrentLocation.model) then
+            if NpcOn and CurrentLocation then
+                if GetEntityModel(targetVehicle) ~= joaat(CurrentLocation.model) then
                     QBCore.Functions.Notify(Lang:t("error.vehicle_not_correct"), "error")
                     return
                 end
@@ -324,7 +323,8 @@ RegisterNetEvent('qb-tow:client:TowVehicle', function()
                                 SetBlipColour(CurrentBlip2, 3)
                                 SetBlipRoute(CurrentBlip2, true)
                                 SetBlipRouteColour(CurrentBlip2, 3)
-                                TriggerServerEvent('qb-tow:server:nano', targetVehicle)
+                                local vehNetID = NetworkGetNetworkIdFromEntity(targetVehicle)
+                                TriggerServerEvent('qb-tow:server:nano', vehNetID)
                                 --remove zone
                                 CurrentLocation.zoneCombo:destroy()
                             end

--- a/server/main.lua
+++ b/server/main.lua
@@ -28,16 +28,18 @@ RegisterNetEvent('qb-tow:server:DoBail', function(bool, vehInfo)
     end
 end)
 
-RegisterNetEvent('qb-tow:server:nano', function(targetVehicle)
+RegisterNetEvent('qb-tow:server:nano', function(vehNetID)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
+    local targetVehicle = NetworkGetEntityFromNetworkId(vehNetID)
     if not Player then return end
 
     local playerPed = GetPlayerPed(src)
     local playerVehicle = GetVehiclePedIsIn(playerPed, true)
     local playerVehicleCoords = GetEntityCoords(playerVehicle)
     local targetVehicleCoords = GetEntityCoords(targetVehicle)
-    if Player.PlayerData.job.name ~= "tow" or #(playerVehicleCoords - targetVehicleCoords) > 11.0 then
+    local dist = #(playerVehicleCoords - targetVehicleCoords)
+    if Player.PlayerData.job.name ~= "tow" or dist > 11.0 then
         return DropPlayer(src, "Attempted exploit abuse")
     end
 


### PR DESCRIPTION
…sations. Fixes #40

**Describe Pull request**
This PR fixes an issue with the server sided distance check causing a false positive and kicking the player. The distance check now uses the NetID to get the correct entity for comparison.

Also some small optimisations are included in this PR.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
