### PR TITLE
Deliver vehicle isn't using the dropoff coords

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -365,7 +365,7 @@ RegisterNetEvent('qb-tow:client:TowVehicle', function()
                 DetachEntity(CurrentTow, true, true)
                 if NpcOn then
                     local targetPos = GetEntityCoords(CurrentTow)
-                    if #(targetPos - vector3(Config.Locations["vehicle"].coords.x, Config.Locations["vehicle"].coords.y, Config.Locations["vehicle"].coords.z)) < 25.0 then
+                    if #(targetPos - vector3(Config.Locations["dropoff"].coords.x, Config.Locations["dropoff"].coords.y, Config.Locations["dropoff"].coords.z)) < 25.0 then
                         deliverVehicle(CurrentTow)
                     end
                 end


### PR DESCRIPTION
**Describe Pull request**
I moved the location of the towjob - I could then not deliver the vehicle. This is because my deliver coords is further than 25.0 from the dropoff coords. So I have updated the code to use the coords of the actual dropoff.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
